### PR TITLE
fix(quic): reject oversized Retry tokens

### DIFF
--- a/src/quic/packet.zig
+++ b/src/quic/packet.zig
@@ -799,9 +799,11 @@ pub fn validateRetryToken(
     token_key: [crypto.key_len]u8,
 ) !?ValidatedToken {
     if (token_data.len < TOKEN_NONCE_LEN + TOKEN_TAG_LEN + 2) return null;
+    if (token_data.len > TOKEN_MAX_LEN) return null;
 
     const nonce = token_data[0..TOKEN_NONCE_LEN].*;
     const ct_len = token_data.len - TOKEN_NONCE_LEN - TOKEN_TAG_LEN;
+    if (ct_len > TOKEN_MAX_PLAINTEXT_LEN) return null;
     const ciphertext = token_data[TOKEN_NONCE_LEN..][0..ct_len];
     const tag = token_data[token_data.len - TOKEN_TAG_LEN ..][0..TOKEN_TAG_LEN].*;
 
@@ -1127,6 +1129,18 @@ test "Retry token: wrong key rejected" {
     var wrong_key: [crypto.key_len]u8 = undefined;
     random.bytes(&wrong_key);
     const validated = try validateRetryToken(out[0..token_len], addr, wrong_key);
+    try std.testing.expect(validated == null);
+}
+
+test "Retry token: oversized token rejected before decrypt" {
+    var token_key: [crypto.key_len]u8 = undefined;
+    random.bytes(&token_key);
+
+    var addr: posix.sockaddr.storage = std.mem.zeroes(posix.sockaddr.storage);
+    addr.family = posix.AF.INET;
+
+    var oversized: [TOKEN_MAX_LEN + 1]u8 = .{0} ** (TOKEN_MAX_LEN + 1);
+    const validated = try validateRetryToken(&oversized, addr, token_key);
     try std.testing.expect(validated == null);
 }
 


### PR DESCRIPTION
## Summary
- reject Retry tokens whose encoded size exceeds the implementation's fixed plaintext capacity before attempting AEAD decryption
- keep `validateRetryToken()` aligned with `TOKEN_MAX_PLAINTEXT_LEN` / `TOKEN_MAX_LEN`
- add a regression test that exercises an oversized token length and expects clean rejection

## Vulnerability
This Retry token format is implemented as:
- nonce: 12 bytes
- encrypted plaintext: up to 64 bytes
- tag: 16 bytes

That means the largest valid Retry token for this implementation is 92 bytes. Before this change, `validateRetryToken()` only checked the *minimum* token size, then derived `ct_len` from the attacker-controlled token length and immediately sliced `plaintext[0..ct_len]` for AES-GCM decryption.

A remote peer could therefore send an Initial packet carrying an oversized Retry token, for example:
- 93 bytes total token length, which makes `ct_len = 65` and already exceeds the 64-byte plaintext buffer
- a much larger token (for example 256 or 512 bytes), which drives the same out-of-bounds slice even further

In safe builds that panics during validation; in unchecked builds it risks writing past the fixed stack buffer in this network-facing token parser.

## Validation
- `zig build test`
- `zig build`
- `zig build fuzz`

## References
- RFC 9000 section 8.1.2 (Retry-based address validation): https://datatracker.ietf.org/doc/html/rfc9000#section-8.1.2
- RFC 9000 section 17.2.5 (Retry packets): https://datatracker.ietf.org/doc/html/rfc9000#section-17.2.5
