### PR TITLE
fix(tls): bound PSK identity length before decrypt

### DIFF
--- a/src/quic/tls13.zig
+++ b/src/quic/tls13.zig
@@ -1828,6 +1828,10 @@ pub const Tls13Handshake = struct {
         // Decrypt ticket identity to get PSK
         if (identity_len < 16 + 1) return; // at least tag + 1 byte
         const ciphertext_len = identity_len - 16;
+        const max_ticket_plaintext_len = 64;
+        const max_ticket_identity_len = max_ticket_plaintext_len + 16;
+        if (identity_len > max_ticket_identity_len) return;
+        if (ciphertext_len > max_ticket_plaintext_len) return;
 
         // Reconstruct nonce from ticket (we use the last 4 bytes of identity as hint)
         var ticket_nonce: [12]u8 = .{0} ** 12;
@@ -3102,6 +3106,33 @@ test "loopback PSK resumption: two handshakes with session ticket" {
         &client2.key_schedule.server_app_traffic_secret,
         &server2.key_schedule.server_app_traffic_secret,
     );
+}
+
+test "tryProcessPsk rejects oversized ticket identity before decrypt" {
+    const tp = transport_params.TransportParams{
+        .initial_max_data = 1048576,
+        .initial_max_streams_bidi = 100,
+    };
+
+    const server_config = TlsConfig{
+        .cert_chain_der = &.{},
+        .private_key_bytes = &.{},
+        .alpn = &[_][]const u8{"h3"},
+        .ticket_key = .{0xA5} ** 16,
+    };
+
+    var handshake = Tls13Handshake.initServer(server_config, tp);
+
+    var psk_ext: [124]u8 = .{0} ** 124;
+    std.mem.writeInt(u16, psk_ext[0..2], 87, .big);
+    std.mem.writeInt(u16, psk_ext[2..4], 81, .big);
+    std.mem.writeInt(u32, psk_ext[85..89], 0, .big);
+    std.mem.writeInt(u16, psk_ext[89..91], 33, .big);
+    psk_ext[91] = 32;
+
+    handshake.tryProcessPsk("", "", 0, &psk_ext, 0, psk_ext.len);
+
+    try std.testing.expect(!handshake.using_psk);
 }
 
 // NewSessionTicket roundtrip test

--- a/src/quic/tls13.zig
+++ b/src/quic/tls13.zig
@@ -1827,23 +1827,21 @@ pub const Tls13Handshake = struct {
 
         // Decrypt ticket identity to get PSK
         if (identity_len < 16 + 1) return; // at least tag + 1 byte
+        var decrypted: [64]u8 = undefined;
+        var ct_copy: [decrypted.len + 16]u8 = undefined;
+        if (identity_len > ct_copy.len) return;
         const ciphertext_len = identity_len - 16;
-        const max_ticket_plaintext_len = 64;
-        const max_ticket_identity_len = max_ticket_plaintext_len + 16;
-        if (identity_len > max_ticket_identity_len) return;
-        if (ciphertext_len > max_ticket_plaintext_len) return;
+        if (ciphertext_len > decrypted.len) return;
 
         // Reconstruct nonce from ticket (we use the last 4 bytes of identity as hint)
         var ticket_nonce: [12]u8 = .{0} ** 12;
         // Use zeros as nonce — server encrypts with incrementing nonce_buf in [8..12]
         // We need to try nonce counter values. For simplicity, try a few.
-        var decrypted: [64]u8 = undefined;
         var psk_found = false;
         var found_psk: [32]u8 = undefined;
 
         for (0..256) |nonce_try| {
             std.mem.writeInt(u32, ticket_nonce[8..12], @intCast(nonce_try), .big);
-            var ct_copy: [80]u8 = undefined;
             @memcpy(ct_copy[0..identity_len], identity[0..identity_len]);
             const tag_start = ciphertext_len;
             const tag: [16]u8 = ct_copy[tag_start..][0..16].*;


### PR DESCRIPTION
## Summary
- reject oversized TLS 1.3 PSK ticket identities before copying or decrypting them into fixed-size stack buffers
- keep invalid oversized identities on the normal PSK rejection path instead of letting them reach `@memcpy`/AEAD output slices
- add a regression test that feeds an oversized PSK identity directly into `tryProcessPsk`

## Vulnerability
`tryProcessPsk` reads `identity_len` from the client-controlled `pre_shared_key` extension, then copies that identity into an 80-byte stack buffer and decrypts it into a 64-byte stack buffer without first proving the length fits. A malicious client can keep the extension internally well-formed while choosing an identity length that exceeds those buffers.

Concrete examples:
- an `identity_len` of `81` bytes stays extension-valid, but it drives `ciphertext_len` to `65`, which exceeds the 64-byte plaintext buffer
- a larger identity such as `96` bytes would overrun both the 80-byte ticket buffer and the decrypt output slice
- because this runs on the server's network-facing ClientHello path, a hostile client can repeatedly trigger remote crashes and, in unchecked builds, memory corruption

## Validation
- `zig build test`
- `zig build`
- `zig build fuzz`

## References
- RFC 8446 section 4.2.11: https://datatracker.ietf.org/doc/html/rfc8446#section-4.2.11
- RFC 8446 section 7.1: https://datatracker.ietf.org/doc/html/rfc8446#section-7.1
- QUIC TLS mapping in RFC 9001 section 4: https://datatracker.ietf.org/doc/html/rfc9001#section-4